### PR TITLE
Correct lifetime for callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Christian Perez-Llamas"]
 description = "CoreMIDI library for Rust"
 license = "MIT"

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -11,7 +11,7 @@ fn main() {
 
     let client = coremidi::Client::new("example-client").unwrap();
 
-    let callback = |packet_list: coremidi::PacketList| {
+    let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 

--- a/examples/virtual-destination.rs
+++ b/examples/virtual-destination.rs
@@ -3,7 +3,7 @@ extern crate coremidi;
 fn main() {
     let client = coremidi::Client::new("example-client").unwrap();
 
-    let callback = |packet_list: coremidi::PacketList| {
+    let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 


### PR DESCRIPTION
Stores the callbacks (for notifications and input both) in boxes, so
both the function and its destructor can be type-erased. Also changes
the basic callback type to FnMut(&Data) + Send + 'static, to indicate
that the callback can be called from a different thread and after the
function registering the callback returns, and that the callback
doesn't get to hold any references to the data.

Also changes the signature of Packet to just yield a data slice; the
old approach of returning an iterator was unsafe because the iterator
could outlive the data pointer. Some packet types get lifetimes and
PhantomData enforcing those lifetimes as well.

Increments the version to 0.2.0, is the change to the callback and
packet types is clearly breaking from a semver perspective.

Fixes #2