### PR TITLE
Handle failure in from_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use std::time::Duration;
 use std::thread;
 let client = Client::new("example-client").unwrap();
 let output_port = client.output_port("example-port").unwrap();
-let destination = Destinations::from_index(0);
+let destination = Destinations::from_index(0).unwrap();
 let note_on = PacketBuffer::from_data(0, vec![0x90, 0x40, 0x7f]);
 let note_off = PacketBuffer::from_data(0, vec![0x80, 0x40, 0x7f]);
 output_port.send(&destination, &note_on).unwrap();

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -6,7 +6,7 @@ fn main() {
     let source_index = get_source_index();
     println!("Source index: {}", source_index);
 
-    let source = coremidi::Source::from_index(source_index);
+    let source = coremidi::Source::from_index(source_index).unwrap();
     println!("Source display name: {}", source.display_name().unwrap());
 
     let client = coremidi::Client::new("example-client").unwrap();

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -8,7 +8,7 @@ fn main() {
     let destination_index = get_destination_index();
     println!("Destination index: {}", destination_index);
 
-    let destination = coremidi::Destination::from_index(destination_index);
+    let destination = coremidi::Destination::from_index(destination_index).unwrap();
     println!("Destination display name: {}", destination.display_name().unwrap());
 
     let client = coremidi::Client::new("example-client").unwrap();

--- a/src/endpoints/destinations.rs
+++ b/src/endpoints/destinations.rs
@@ -13,9 +13,12 @@ impl Destination {
     /// Create a destination endpoint from its index.
     /// See [MIDIGetDestination](https://developer.apple.com/reference/coremidi/1495108-midigetdestination)
     ///
-    pub fn from_index(index: usize) -> Destination {
+    pub fn from_index(index: usize) -> Option<Destination> {
         let endpoint_ref = unsafe { MIDIGetDestination(index as ItemCount) };
-        Destination { endpoint: Endpoint { object: Object(endpoint_ref) } }
+        match endpoint_ref {
+            0 => None,
+            _ => Some(Destination { endpoint: Endpoint { object: Object(endpoint_ref) } })
+        }
     }
 }
 
@@ -73,7 +76,7 @@ impl Iterator for DestinationsIterator {
 
     fn next(&mut self) -> Option<Destination> {
         if self.index < self.count {
-            let destination = Some(Destination::from_index(self.index));
+            let destination = Destination::from_index(self.index);
             self.index += 1;
             destination
         }

--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -20,9 +20,12 @@ impl Source {
     /// Create a source endpoint from its index.
     /// See [MIDIGetSource](https://developer.apple.com/reference/coremidi/1495168-midigetsource)
     ///
-    pub fn from_index(index: usize) -> Source {
+    pub fn from_index(index: usize) -> Option<Source> {
         let endpoint_ref = unsafe { MIDIGetSource(index as ItemCount) };
-        Source { endpoint: Endpoint { object: Object(endpoint_ref) } }
+        match endpoint_ref {
+            0 => None,
+            _ => Some(Source { endpoint: Endpoint { object: Object(endpoint_ref) } })
+        }
     }
 }
 
@@ -80,7 +83,7 @@ impl Iterator for SourcesIterator {
 
     fn next(&mut self) -> Option<Source> {
         if self.index < self.count {
-            let source = Some(Source::from_index(self.index));
+            let source = Source::from_index(self.index);
             self.index += 1;
             source
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use std::thread;
 let client = coremidi::Client::new("example-client").unwrap();
 let output_port = client.output_port("example-port").unwrap();
-let destination = coremidi::Destination::from_index(0);
+let destination = coremidi::Destination::from_index(0).unwrap();
 let note_on = coremidi::PacketBuffer::from_data(0, vec![0x90, 0x40, 0x7f]);
 let note_off = coremidi::PacketBuffer::from_data(0, vec![0x80, 0x40, 0x7f]);
 output_port.send(&destination, &note_on).unwrap();
@@ -125,7 +125,7 @@ pub struct Port { object: Object }
 /// ```rust,no_run
 /// let client = coremidi::Client::new("example-client").unwrap();
 /// let output_port = client.output_port("example-port").unwrap();
-/// let destination = coremidi::Destination::from_index(0);
+/// let destination = coremidi::Destination::from_index(0).unwrap();
 /// let packets = coremidi::PacketBuffer::from_data(0, vec![0x90, 0x40, 0x7f]);
 /// output_port.send(&destination, &packets).unwrap();
 /// ```
@@ -139,7 +139,7 @@ pub struct OutputPort { port: Port }
 /// ```rust,no_run
 /// let client = coremidi::Client::new("example-client").unwrap();
 /// let input_port = client.input_port("example-port", |packet_list| println!("{}", packet_list)).unwrap();
-/// let source = coremidi::Source::from_index(0);
+/// let source = coremidi::Source::from_index(0).unwrap();
 /// input_port.connect_source(&source);
 /// ```
 #[derive(Debug)]
@@ -162,7 +162,7 @@ pub struct Endpoint { object: Object }
 /// A source can be created from an index like this:
 ///
 /// ```rust,no_run
-/// let source = coremidi::Destination::from_index(0);
+/// let source = coremidi::Destination::from_index(0).unwrap();
 /// println!("The source at index 0 has display name '{}'", source.display_name().unwrap());
 /// ```
 ///
@@ -174,7 +174,7 @@ pub struct Destination { endpoint: Endpoint }
 /// A source can be created from an index like this:
 ///
 /// ```rust,no_run
-/// let source = coremidi::Source::from_index(0);
+/// let source = coremidi::Source::from_index(0).unwrap();
 /// println!("The source at index 0 has display name '{}'", source.display_name().unwrap());
 /// ```
 ///


### PR DESCRIPTION
Fixes #4. I decided to return an `Option` instead of a `Result`, because there is no further information in the error case.