### PR TITLE
Correctly dispose virtual endpoints

### DIFF
--- a/src/endpoints/destinations.rs
+++ b/src/endpoints/destinations.rs
@@ -1,5 +1,5 @@
 use coremidi_sys::{
-    MIDIGetNumberOfDestinations, MIDIGetDestination, ItemCount
+    MIDIGetNumberOfDestinations, MIDIGetDestination, MIDIEndpointDispose, ItemCount
 };
 
 use std::ops::Deref;
@@ -92,5 +92,11 @@ impl Deref for VirtualDestination {
 
     fn deref(&self) -> &Endpoint {
         &self.endpoint
+    }
+}
+
+impl Drop for VirtualDestination {
+    fn drop(&mut self) {
+        unsafe { MIDIEndpointDispose(self.endpoint.object.0) };
     }
 }

--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -1,7 +1,7 @@
 use core_foundation_sys::base::OSStatus;
 
 use coremidi_sys::{
-    MIDIGetNumberOfSources, MIDIGetSource, ItemCount
+    MIDIGetNumberOfSources, MIDIGetSource, MIDIEndpointDispose, ItemCount
 };
 
 use coremidi_sys_ext::{
@@ -108,5 +108,11 @@ impl Deref for VirtualSource {
 
     fn deref(&self) -> &Endpoint {
         &self.endpoint
+    }
+}
+
+impl Drop for VirtualSource {
+    fn drop(&mut self) {
+        unsafe { MIDIEndpointDispose(self.endpoint.object.0) };
     }
 }


### PR DESCRIPTION
It is required to call [`MIDIEndpointDispose`](https://developer.apple.com/documentation/coremidi/1495148-midiendpointdispose) on virtual sources and destinations.