### PR TITLE
Flesh out Device, add Entity

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -1,12 +1,122 @@
+use coremidi_sys::{
+    MIDIGetNumberOfDevices, MIDIGetDevice, MIDIDeviceGetNumberOfEntities, MIDIDeviceGetEntity,
+    ItemCount
+};
+
 use Object;
 use Device;
+use Entity;
 
 use std::ops::Deref;
+
+impl Device {
+    /// Get a device from its index.
+    /// See [MIDIGetDevice](https://developer.apple.com/documentation/coremidi/1495368-midigetdevice)
+    ///
+    pub fn from_index(index: usize) -> Option<Device> {
+        let device_ref = unsafe { MIDIGetDevice(index as ItemCount) };
+        match device_ref {
+            0 => None,
+            _ => Some(Device { object: Object(device_ref) })
+        }
+    }
+
+    pub fn entity_count(&self) -> usize {
+        unsafe { MIDIDeviceGetNumberOfEntities(self.object.0) as usize }
+    }
+
+    pub fn entities(&self) -> DeviceEntitiesIterator {
+        DeviceEntitiesIterator { device: &self, index: 0, count: self.entity_count() }
+    }
+}
 
 impl Deref for Device {
     type Target = Object;
 
     fn deref(&self) -> &Object {
         &self.object
+    }
+}
+
+/// Devices available in the system.
+///
+/// The number of devices available in the system can be retrieved with:
+///
+/// ```
+/// let number_of_devices = coremidi::Devices::count();
+/// ```
+///
+/// The devices in the system can be iterated as:
+///
+/// ```rust,no_run
+/// for device in coremidi::Devices {
+///   println!("{}", device.display_name().unwrap());
+/// }
+/// ```
+///
+pub struct Devices;
+
+impl Devices {
+    /// Get the number of devices available in the system for sending MIDI messages.
+    /// See [MIDIGetNumberOfDevices](https://developer.apple.com/documentation/coremidi/1495164-midigetnumberofdevices).
+    ///
+    pub fn count() -> usize {
+        unsafe { MIDIGetNumberOfDevices() as usize }
+    }
+}
+
+impl IntoIterator for Devices {
+    type Item = Device;
+    type IntoIter = DevicesIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        DevicesIterator { index: 0, count: Self::count() }
+    }
+}
+
+pub struct DevicesIterator {
+    index: usize,
+    count: usize
+}
+
+impl Iterator for DevicesIterator {
+    type Item = Device;
+
+    fn next(&mut self) -> Option<Device> {
+        if self.index < self.count {
+            let device = Device::from_index(self.index);
+            self.index += 1;
+            device
+        }
+        else {
+            None
+        }
+    }
+}
+
+pub struct DeviceEntitiesIterator<'a> {
+    device: &'a Device,
+    index: usize,
+    count: usize
+}
+
+impl<'a> Iterator for DeviceEntitiesIterator<'a> {
+    type Item = Entity;
+
+    fn next(&mut self) -> Option<Entity> {
+        if self.index < self.count {
+            let entity_ref =
+                unsafe { MIDIDeviceGetEntity(self.device.object.0, self.index as u64) };
+            self.index += 1;
+            if entity_ref == 0 {
+                Some(Entity { object: Object(entity_ref) })
+            }
+            else {
+                None
+            }
+        }
+        else {
+            None
+        }
     }
 }

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,0 +1,95 @@
+use coremidi_sys::{
+    MIDIEntityGetNumberOfDestinations, MIDIEntityGetDestination,
+    MIDIEntityGetNumberOfSources, MIDIEntityGetSource,
+    MIDIEntityGetDevice
+};
+
+use Object;
+use Entity;
+use Device;
+use Destination;
+use Source;
+use Endpoint;
+
+impl Entity {
+    pub fn destination_count(&self) -> usize {
+        unsafe { MIDIEntityGetNumberOfDestinations(self.object.0) as usize }
+    }
+
+    pub fn destinations(&self) -> EntityDestinationIterator {
+        EntityDestinationIterator { entity: &self, index: 0, count: self.destination_count() }
+    }
+
+    pub fn source_count(&self) -> usize {
+        unsafe { MIDIEntityGetNumberOfSources(self.object.0) as usize }
+    }
+
+    pub fn sources(&self) -> EntitySourceIterator {
+        EntitySourceIterator { entity: &self, index: 0, count: self.source_count() }
+    }
+
+    pub fn get_device(&self) -> Option<Device> {
+        let device_ref = 0 as *mut u32;
+        let res = unsafe { MIDIEntityGetDevice(self.object.0, device_ref) };
+        if res == 0 {
+            Some(Device { object: Object(unsafe { *device_ref }) })
+        }
+        else {
+            None
+        }
+    }
+}
+
+pub struct EntityDestinationIterator<'a> {
+    entity: &'a Entity,
+    index: usize,
+    count: usize
+}
+
+impl<'a> Iterator for EntityDestinationIterator<'a> {
+    type Item = Destination;
+
+    fn next(&mut self) -> Option<Destination> {
+        if self.index < self.count {
+            let destination_ref =
+                unsafe { MIDIEntityGetDestination(self.entity.object.0, self.index as u64) };
+            self.index += 1;
+            if destination_ref == 0 {
+                None
+            }
+            else {
+                Some(Destination {endpoint: Endpoint { object: Object(destination_ref) }})
+            }
+        }
+        else {
+            None
+        }
+    }
+}
+
+pub struct EntitySourceIterator<'a> {
+    entity: &'a Entity,
+    index: usize,
+    count: usize
+}
+
+impl<'a> Iterator for EntitySourceIterator<'a> {
+    type Item = Source;
+
+    fn next(&mut self) -> Option<Source> {
+        if self.index < self.count {
+            let source_ref =
+                unsafe { MIDIEntityGetSource(self.entity.object.0, self.index as u64) };
+            self.index += 1;
+            if source_ref == 0 {
+                None
+            }
+            else {
+                Some(Source {endpoint: Endpoint { object: Object(source_ref) }})
+            }
+        }
+        else {
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,7 @@ mod endpoints;
 mod notifications;
 pub use endpoints::destinations::Destinations;
 pub use endpoints::sources::Sources;
+pub use devices::Devices;
 pub use packets::{PacketListIterator, Packet, PacketBuffer};
 pub use properties::{Properties, PropertyGetter, PropertySetter};
 pub use notifications::Notification;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,13 +204,21 @@ pub struct VirtualDestination {
     callback: BoxedCallback<PacketList>,
 }
 
-/// A [MIDI object](https://developer.apple.com/reference/coremidi/midideviceref).
+/// A [MIDI device](https://developer.apple.com/reference/coremidi/midideviceref).
 ///
 /// A MIDI device or external device, containing entities.
 ///
 #[derive(Debug)]
 #[derive(PartialEq)]
 pub struct Device { object: Object }
+
+/// A [MIDI entity](https://developer.apple.com/documentation/coremidi/midientityref).
+///
+/// A MIDI entity, owned by a device, containing endpoints.
+///
+#[derive(Debug)]
+#[derive(PartialEq)]
+pub struct Entity { object: Object }
 
 /// A [list of MIDI events](https://developer.apple.com/reference/coremidi/midipacketlist) being received from, or being sent to, one endpoint.
 ///
@@ -239,6 +247,7 @@ impl PacketList {
 
 mod object;
 mod devices;
+mod entities;
 mod client;
 mod ports;
 mod packets;


### PR DESCRIPTION
In my own toy application, I wanted to ensure that the `Source` and `Destination` that I had were associated. Reading through the CoreMIDI docs, it seemed like I wanted a `Device`, but there wasn't a way to get one, and nothing useful to be done with it once I got one in rust. Hopefully, with this pull request, this is no longer the case.

I tried to stick to the style of the project as it stands, but I may have taken excessive liberties in certain places. The code (although mostly boilerplate) is also largely untested at this stage, so there are probably still bugs (particularly around `unsafe` code, especially around raw pointers).