### PR TITLE
Set Version Number in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi"
-version = "0.0.0"
+version = "0.4.0"
 authors = ["Christian Perez-Llamas"]
 description = "CoreMIDI library for Rust"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The library is published into [crates.io](https://crates.io/crates/coremidi), so
 
 ```toml
 [dependencies]
-coremidi = "^0.3.1"
+coremidi = "^0.4.0"
 ```
 
 If you prefer to live in the edge ;-) you can use the master branch by including this instead:


### PR DESCRIPTION
Just updates `Cargo.toml` and `README` to show the current version number.

Of course, both of these locations should be updated again the next time a release is made for this crate on Crates.io - this pull request is just intended to get the process started.

The reason for this change is not just consistency - having the crate uploaded to Crates.io without a version number in the `Cargo.toml` makes [patching the dependency](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html) not work as expected, making it harder to contribute to this repo.

Thank you! 🙏