### PR TITLE
Fixes crash in tests

### DIFF
--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -286,12 +286,13 @@ mod tests {
 
     #[test]
     fn notification_from_property_changed_error() {
+        let name = CFString::new("name");
         let notification_raw = MIDIObjectPropertyChangeNotification {
             messageID: kMIDIMsgPropertyChanged as MIDINotificationMessageID,
             messageSize: 24,
             object: 1 as MIDIObjectRef,
             objectType: 0xffff,
-            propertyName: CFString::new("name").as_concrete_TypeRef()
+            propertyName: name.as_concrete_TypeRef()
         };
 
         let notification = Notification::from(

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -261,12 +261,13 @@ mod tests {
 
     #[test]
     fn notification_from_property_changed() {
+        let name = CFString::new("name");
         let notification_raw = MIDIObjectPropertyChangeNotification {
             messageID: kMIDIMsgPropertyChanged as MIDINotificationMessageID,
             messageSize: 24,
             object: 1 as MIDIObjectRef,
             objectType: kMIDIObjectType_Device,
-            propertyName: CFString::new("name").as_concrete_TypeRef()
+            propertyName: name.as_concrete_TypeRef()
         };
 
         let notification = Notification::from(

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -99,7 +99,7 @@ impl Notification {
             Ok(object_type) => {
                 let property_name = {
                     let name_ref: CFStringRef = property_changed_notification.propertyName;
-                    let name: CFString = unsafe { TCFType::wrap_under_create_rule(name_ref) };
+                    let name: CFString = unsafe { TCFType::wrap_under_get_rule(name_ref) };
                     name.to_string()
                 };
                 let property_changed_info = PropertyChangedInfo {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -100,7 +100,7 @@ impl Notification {
                 let property_name = {
                     let name_ref: CFStringRef = property_changed_notification.propertyName;
                     let name: CFString = unsafe { TCFType::wrap_under_create_rule(name_ref) };
-                    format!("{}", name)
+                    name.to_string()
                 };
                 let property_changed_info = PropertyChangedInfo {
                     object: Object(property_changed_notification.object),

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -104,8 +104,8 @@ impl Notification {
                 };
                 let property_changed_info = PropertyChangedInfo {
                     object: Object(property_changed_notification.object),
-                    object_type: object_type,
-                    property_name: property_name
+                    object_type,
+                    property_name
                 };
                 Ok(Notification::PropertyChanged(property_changed_info))
             },


### PR DESCRIPTION
Hey there! This fixes #17. You can see the details by clicking through and reading the full commit messages on these two commits:

- [Gave test data the proper retain count](https://github.com/chris-zen/coremidi/commit/ab07a719b86202f9dd86bdc0dfca6b440b2c09d8)
- [Fixing SIGILL in tests caused by over-release of CFStringRef](https://github.com/chris-zen/coremidi/commit/c9a6f18c5c69fa6524a0b243f91fa90fa8e6f886)

The rest was just some super minor cleanup I did along the way while figuring it out. Thanks so much, and hope this helps!