### PR TITLE
Fixes Virtual Destination Example

### DIFF
--- a/examples/endpoints.rs
+++ b/examples/endpoints.rs
@@ -8,7 +8,8 @@ fn main() {
         println!("[{}] {}", i, display_name);
     }
 
-    println!("\nSystem sources:");
+    println!("");
+    println!("System sources:");
 
     for (i, source) in coremidi::Sources.into_iter().enumerate() {
         let display_name = get_display_name(&source);

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -9,17 +9,17 @@ fn main() {
     let source = coremidi::Source::from_index(source_index).unwrap();
     println!("Source display name: {}", source.display_name().unwrap());
 
-    let client = coremidi::Client::new("example-client").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 
-    let input_port = client.input_port("example-port", callback).unwrap();
+    let input_port = client.input_port("Example Port", callback).unwrap();
     input_port.connect_source(&source).unwrap();
 
     let mut input_line = String::new();
-    println!("Press [Intro] to finish ...");
+    println!("Press Enter to Finish");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 
     input_port.disconnect_source(&source).unwrap();

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -11,8 +11,8 @@ fn main() {
     let destination = coremidi::Destination::from_index(destination_index).unwrap();
     println!("Destination display name: {}", destination.display_name().unwrap());
 
-    let client = coremidi::Client::new("example-client").unwrap();
-    let output_port = client.output_port("example-port").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
+    let output_port = client.output_port("Example Port").unwrap();
 
     let note_on = create_note_on(0, 64, 127);
     let note_off = create_note_off(0, 64, 127);

--- a/examples/virtual-destination.rs
+++ b/examples/virtual-destination.rs
@@ -1,7 +1,7 @@
 extern crate coremidi;
 
 fn main() {
-    let client = coremidi::Client::new("CoreMidi Example Client").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
@@ -11,6 +11,6 @@ fn main() {
 
     let mut input_line = String::new();
     println!("Created Virtual Destination \"Example Destination\"");
-    println!("Press Enter to Exit");
+    println!("Press Enter to Finish");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 }

--- a/examples/virtual-destination.rs
+++ b/examples/virtual-destination.rs
@@ -1,15 +1,16 @@
 extern crate coremidi;
 
 fn main() {
-    let client = coremidi::Client::new("example-client").unwrap();
+    let client = coremidi::Client::new("CoreMidi Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 
-    client.virtual_destination("example-destination", callback).unwrap();
+    let _destination = client.virtual_destination("Example Destination", callback).unwrap();
 
     let mut input_line = String::new();
-    println!("Press [Intro] to finish ...");
+    println!("Created Virtual Destination \"Example Destination\"");
+    println!("Press Enter to Exit");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 }

--- a/examples/virtual-source.rs
+++ b/examples/virtual-source.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 use std::thread;
 
 fn main() {
-    let client = coremidi::Client::new("example-client").unwrap();
-    let source = client.virtual_source("example-source").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
+    let source = client.virtual_source("Example Source").unwrap();
 
     let note_on = create_note_on(0, 64, 127);
     let note_off = create_note_off(0, 64, 127);
 
     for i in 0..10 {
-        println!("[{}] Received note ...", i);
+        println!("[{}] Sending note...", i);
 
         source.received(&note_on).unwrap();
 


### PR DESCRIPTION
Previously, the Virtual Destination example wouldn't seem like it worked because the virtual destination was dropped immediately upon creation. Assigning it to a local variable fixes this.

Also makes the text clearer and more consistent in the other examples.