### PR TITLE
Fix CoreFoundation Lifetime Issues with Properties

### DIFF
--- a/examples/endpoints.rs
+++ b/examples/endpoints.rs
@@ -8,7 +8,8 @@ fn main() {
         println!("[{}] {}", i, display_name);
     }
 
-    println!("\nSystem sources:");
+    println!("");
+    println!("System sources:");
 
     for (i, source) in coremidi::Sources.into_iter().enumerate() {
         let display_name = get_display_name(&source);

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -1,14 +1,17 @@
 extern crate coremidi;
 
 use coremidi::{
+    Client,
+    PacketList,
+    Properties,
     PropertyGetter,
     PropertySetter, 
 };
 
 fn main() {
-    let client = coremidi::Client::new("Example Client").unwrap();
+    let client = Client::new("Example Client").unwrap();
 
-    let callback = |packet_list: &coremidi::PacketList| {
+    let callback = |packet_list: &PacketList| {
         println!("{}", packet_list);
     };
 
@@ -16,6 +19,11 @@ fn main() {
     let destination = client.virtual_destination("Example Destination", callback).unwrap();
 
     println!("Created Virtual Destination...");
-    let name: String = coremidi::Properties::name().value_from(&destination).unwrap();
+
+    // How to get a property
+    let name: String = Properties::name().value_from(&destination).unwrap();
     println!("With Name: {}", name);
+
+    // How to set a property
+    Properties::private().set_value(&destination, true).unwrap();
 }

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -1,0 +1,21 @@
+extern crate coremidi;
+
+use coremidi::{
+    PropertyGetter,
+    PropertySetter, 
+};
+
+fn main() {
+    let client = coremidi::Client::new("Example Client").unwrap();
+
+    let callback = |packet_list: &coremidi::PacketList| {
+        println!("{}", packet_list);
+    };
+
+    // Creates a virtual destination, then gets its properties
+    let destination = client.virtual_destination("Example Destination", callback).unwrap();
+
+    println!("Created Virtual Destination...");
+    let name: String = coremidi::Properties::name().value_from(&destination).unwrap();
+    println!("With Name: {}", name);
+}

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -9,17 +9,17 @@ fn main() {
     let source = coremidi::Source::from_index(source_index).unwrap();
     println!("Source display name: {}", source.display_name().unwrap());
 
-    let client = coremidi::Client::new("example-client").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 
-    let input_port = client.input_port("example-port", callback).unwrap();
+    let input_port = client.input_port("Example Port", callback).unwrap();
     input_port.connect_source(&source).unwrap();
 
     let mut input_line = String::new();
-    println!("Press [Intro] to finish ...");
+    println!("Press Enter to Finish");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 
     input_port.disconnect_source(&source).unwrap();

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -11,8 +11,8 @@ fn main() {
     let destination = coremidi::Destination::from_index(destination_index).unwrap();
     println!("Destination display name: {}", destination.display_name().unwrap());
 
-    let client = coremidi::Client::new("example-client").unwrap();
-    let output_port = client.output_port("example-port").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
+    let output_port = client.output_port("Example Port").unwrap();
 
     let note_on = create_note_on(0, 64, 127);
     let note_off = create_note_off(0, 64, 127);

--- a/examples/virtual-destination.rs
+++ b/examples/virtual-destination.rs
@@ -1,7 +1,7 @@
 extern crate coremidi;
 
 fn main() {
-    let client = coremidi::Client::new("CoreMidi Example Client").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
@@ -11,6 +11,6 @@ fn main() {
 
     let mut input_line = String::new();
     println!("Created Virtual Destination \"Example Destination\"");
-    println!("Press Enter to Exit");
+    println!("Press Enter to Finish");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 }

--- a/examples/virtual-destination.rs
+++ b/examples/virtual-destination.rs
@@ -1,15 +1,16 @@
 extern crate coremidi;
 
 fn main() {
-    let client = coremidi::Client::new("example-client").unwrap();
+    let client = coremidi::Client::new("CoreMidi Example Client").unwrap();
 
     let callback = |packet_list: &coremidi::PacketList| {
         println!("{}", packet_list);
     };
 
-    client.virtual_destination("example-destination", callback).unwrap();
+    let _destination = client.virtual_destination("Example Destination", callback).unwrap();
 
     let mut input_line = String::new();
-    println!("Press [Intro] to finish ...");
+    println!("Created Virtual Destination \"Example Destination\"");
+    println!("Press Enter to Exit");
     std::io::stdin().read_line(&mut input_line).ok().expect("Failed to read line");
 }

--- a/examples/virtual-source.rs
+++ b/examples/virtual-source.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 use std::thread;
 
 fn main() {
-    let client = coremidi::Client::new("example-client").unwrap();
-    let source = client.virtual_source("example-source").unwrap();
+    let client = coremidi::Client::new("Example Client").unwrap();
+    let source = client.virtual_source("Example Source").unwrap();
 
     let note_on = create_note_on(0, 64, 127);
     let note_off = create_note_off(0, 64, 127);
 
     for i in 0..10 {
-        println!("[{}] Received note ...", i);
+        println!("[{}] Sending note...", i);
 
         source.received(&note_on).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub use notifications::Notification;
 ///
 pub fn flush() -> Result<(), OSStatus> {
     let status = unsafe { MIDIFlushOutput(0) };
-    if status == 0 { Ok(()) } else { Err(status) }
+    unit_result_from_status(status)
 }
 
 /// Stops and restarts MIDI I/O.
@@ -264,5 +264,18 @@ pub fn flush() -> Result<(), OSStatus> {
 ///
 pub fn restart() -> Result<(), OSStatus> {
     let status = unsafe { MIDIRestart() };
-    if status == 0 { Ok(()) } else { Err(status) }
+    unit_result_from_status(status)
+}
+
+/// Convert an OSStatus into a Result<T, OSStatus> given a mapping closure
+fn result_from_status<T, F: FnOnce() -> T>(status: OSStatus, f: F) -> Result<T, OSStatus> {
+    match status {
+        0 => Ok(f()),
+        _ => Err(status),
+    }
+}
+
+/// Convert an OSSStatus into a Result<(), OSStatus>
+fn unit_result_from_status(status: OSStatus) -> Result<(), OSStatus> {
+    result_from_status(status, || ())
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -420,7 +420,6 @@ mod tests {
         #[test]
         fn test_from_constant() {
             let (_client, dest) = setup();
-
             let property = Properties::name();
 
             check_get_original(&property, &dest);
@@ -430,7 +429,6 @@ mod tests {
         #[test]
         fn test_new() {
             let (_client, dest) = setup();
-
             // "name" is the value of the CoreMidi constant kMIDIPropertyName
             let property = StringProperty::new("name");
 
@@ -447,9 +445,9 @@ mod tests {
         #[test]
         fn test_not_set() {
             let (_client, dest) = setup();
-
             // Is not set by default for Virtual Destinations
             let property = Properties::advance_schedule_time_musec();
+
             let value: Result<i32, _> = property.value_from(&dest);
 
             assert!(value.is_err())
@@ -464,6 +462,32 @@ mod tests {
             let num: i32 = property.value_from(&dest).unwrap();
 
             assert_eq!(num, ADVANCED_SCHEDULE_TIME);
+        }
+    }
+
+    mod boolean {
+        use super::*;
+
+        #[test]
+        fn test_not_set() {
+            let (_client, dest) = setup();
+            // Not set by default on Virtual Destinations
+            let property = Properties::transmits_program_changes();
+
+            let value: Result<bool, _> = property.value_from(&dest);
+
+            assert!(value.is_err())
+        }
+
+        #[test]
+        fn test_roundtrip() {
+            let (_client, dest) = setup();
+            let property = Properties::private();
+            
+            property.set_value(&dest, true).unwrap();
+            let value: bool = property.value_from(&dest).unwrap();
+
+            assert!(value, true)
         }
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -66,9 +66,7 @@ impl StringProperty {
 impl<T> PropertyGetter<T> for StringProperty where T: From<String> {
     fn value_from(&self, object: &Object) -> Result<T, OSStatus> {
         let property_key = self.0.as_string_ref();
-        let mut string_ref: CFStringRef = unsafe { 
-            mem::uninitialized()
-        };
+        let mut string_ref: CFStringRef = unsafe { mem::uninitialized() };
         let status = unsafe {
             MIDIObjectGetStringProperty(object.0, property_key, &mut string_ref)
         };
@@ -113,9 +111,7 @@ impl IntegerProperty {
 impl<T> PropertyGetter<T> for IntegerProperty where T: From<SInt32> {
     fn value_from(&self, object: &Object) -> Result<T, OSStatus> {
         let property_key = self.0.as_string_ref();
-        let mut value: SInt32 = unsafe {
-            mem::uninitialized()
-        };
+        let mut value: SInt32 = unsafe { mem::uninitialized() };
         let status = unsafe {
             MIDIObjectGetIntegerProperty(object.0, property_key, &mut value)
         };

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -72,7 +72,7 @@ impl<T> PropertyGetter<T> for StringProperty where T: From<String> {
             let string: CFString = unsafe {
                 TCFType::wrap_under_create_rule(string_ref)
             };
-            Ok(From::<String>::from(format!("{}", string)))
+            Ok(string.to_string().into())
         } else { Err(status) }
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -61,29 +61,32 @@ impl StringProperty {
 
 impl<T> PropertyGetter<T> for StringProperty where T: From<String> {
     fn value_from(&self, object: &Object) -> Result<T, OSStatus> {
-        unsafe {
-            let mut string_ref: CFStringRef = mem::uninitialized();
-            let property_key = self.0.as_string_ref();
-            let status = MIDIObjectGetStringProperty(object.0, property_key, &mut string_ref);
-            if status == 0 {
-                let string: CFString = TCFType::wrap_under_create_rule(string_ref);
-                Ok(From::<String>::from(format!("{}", string)))
-            }
-            else { Err(status) }
-        }
+        let property_key = self.0.as_string_ref();
+        let mut string_ref: CFStringRef = unsafe { 
+            mem::uninitialized()
+        };
+        let status = unsafe {
+            MIDIObjectGetStringProperty(object.0, property_key, &mut string_ref)
+        };
+        if status == 0 {
+            let string: CFString = unsafe {
+                TCFType::wrap_under_create_rule(string_ref)
+            };
+            Ok(From::<String>::from(format!("{}", string)))
+        } else { Err(status) }
     }
 }
 
 impl<'a, T> PropertySetter<T> for StringProperty where T: Into<String> {
     fn set_value(&self, object: &Object, value: T) -> Result<(), OSStatus> {
-        unsafe {
-            let value: String = value.into();
-            let string = CFString::new(&value);
-            let string_ref = string.as_concrete_TypeRef();
-            let property_key = self.0.as_string_ref();
-            let status = MIDIObjectSetStringProperty(object.0, property_key, string_ref);
-            if status == 0 { Ok(()) } else { Err(status) }
-        }
+        let property_key = self.0.as_string_ref();
+        let value: String = value.into();
+        let string = CFString::new(&value);
+        let string_ref = string.as_concrete_TypeRef();
+        let status = unsafe {
+            MIDIObjectSetStringProperty(object.0, property_key, string_ref)
+        };
+        if status == 0 { Ok(()) } else { Err(status) }
     }
 }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -379,3 +379,56 @@ impl Properties {
         StringProperty::from_constant_string_ref(unsafe { kMIDIPropertyDisplayName })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ::{
+        Client,
+        VirtualDestination,
+    };
+
+    const DEST_NAME_ORIG: &str = "A";
+    const DEST_NAME_MODIFIED: &str = "B";
+
+    fn setup() -> (Client, VirtualDestination) {
+        let client = Client::new("Test Client").unwrap();
+        let destination = client.virtual_destination(DEST_NAME_ORIG, |_|()).unwrap();
+        (client, destination)
+    }
+
+    mod string {
+        use super::*;
+
+        fn check_roundtrip(property: StringProperty, destination: &VirtualDestination) {
+            // Test getting the original name
+            let name: String = property.value_from(destination).unwrap();
+            assert_eq!(name, DEST_NAME_ORIG);
+
+            // Test setting then getting the name
+            property.set_value(destination, DEST_NAME_MODIFIED).unwrap();
+            let name: String = property.value_from(destination).unwrap();
+            assert_eq!(name, DEST_NAME_MODIFIED);
+        }
+
+        #[test]
+        fn test_from_constant() {
+            let (_client, dest) = setup();
+
+            let property = Properties::name();
+
+            check_roundtrip(property, &dest);
+        }
+
+        #[test]
+        fn test_new() {
+            let (_client, dest) = setup();
+
+            // "name" is the value of the CoreMidi constant kMIDIPropertyName
+            let property = StringProperty::new("name");
+
+            check_roundtrip(property, &dest);
+        }
+    }
+}

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -120,7 +120,6 @@ impl<T> PropertyGetter<T> for IntegerProperty where T: From<SInt32> {
             MIDIObjectGetIntegerProperty(object.0, property_key, &mut value)
         };
         result_from_status(status, || value.into())
-        // if status == 0 { Ok(From::from(value)) } else { Err(status) }
     }
 }
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -6,7 +6,11 @@ use coremidi_sys::*;
 
 use std::mem;
 
-use Object;
+use {
+    Object,
+    result_from_status,
+    unit_result_from_status,
+};
 
 pub trait PropertyGetter<T> {
     fn value_from(&self, object: &Object) -> Result<T, OSStatus>;
@@ -68,12 +72,12 @@ impl<T> PropertyGetter<T> for StringProperty where T: From<String> {
         let status = unsafe {
             MIDIObjectGetStringProperty(object.0, property_key, &mut string_ref)
         };
-        if status == 0 {
+        result_from_status(status, || {
             let string: CFString = unsafe {
                 TCFType::wrap_under_create_rule(string_ref)
             };
-            Ok(string.to_string().into())
-        } else { Err(status) }
+            string.to_string().into()
+        })
     }
 }
 
@@ -86,7 +90,7 @@ impl<'a, T> PropertySetter<T> for StringProperty where T: Into<String> {
         let status = unsafe {
             MIDIObjectSetStringProperty(object.0, property_key, string_ref)
         };
-        if status == 0 { Ok(()) } else { Err(status) }
+        unit_result_from_status(status)
     }
 }
 


### PR DESCRIPTION
**Note that this PR depends on https://github.com/chris-zen/coremidi/pull/21.**

The main purpose of this PR was to fix https://github.com/chris-zen/coremidi/issues/23.

This PR also includes the following improvements:

- Added tests for setting & getting *-`Property`s
- Added an example for getting & setting Properties (`cargo run --example properties`)
- Removed all `unsafe` in `BooleanProperty` (it's now a wrapper around an `IntegerProperty`)
- Reduced scope of `unsafe` in `StringProperty` and `IntegerProperty`
- Reduced scope of `unsafe` in methods to create Properties from CoreMidi constants
- Spaced out methods to create *-`Property`s from CoreMidi constants to make it easier to read and edit them

This is not a breaking change.