### PR TITLE
Fix Undefined Behavior in Client and Properties

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,8 @@ use coremidi_sys::{
 use std::{
     mem::MaybeUninit,
     ops::Deref, 
+    os::raw::c_void,
+    panic::catch_unwind,
     ptr, 
 };
 
@@ -176,9 +178,9 @@ impl Client {
 
     extern "C" fn notify_proc(
             notification_ptr: *const MIDINotification,
-            ref_con: *mut ::std::os::raw::c_void) {
+            ref_con: *mut c_void) {
 
-        let _ = ::std::panic::catch_unwind(|| unsafe {
+        let _ = catch_unwind(|| unsafe {
             match Notification::from(&*notification_ptr) {
                 Ok(notification) => {
                     BoxedCallback::call_from_raw_ptr(ref_con, &notification);
@@ -190,10 +192,10 @@ impl Client {
 
     extern "C" fn read_proc(
             pktlist: *const MIDIPacketList,
-            read_proc_ref_con: *mut ::std::os::raw::c_void,
-            _: *mut ::std::os::raw::c_void) { //srcConnRefCon
+            read_proc_ref_con: *mut c_void,
+            _: *mut c_void) { //srcConnRefCon
 
-        let _ = ::std::panic::catch_unwind(|| unsafe {
+        let _ = catch_unwind(|| unsafe {
             let packet_list = &*(pktlist as *const PacketList);
             BoxedCallback::call_from_raw_ptr(read_proc_ref_con, packet_list);
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -45,12 +45,10 @@ impl Client {
                 client_ref.as_mut_ptr()
             )
         };
-        if status == 0 {
+        result_from_status(status, || {
             let client_ref = unsafe { client_ref.assume_init() };
-            Ok(Client { object: Object(client_ref), callback: boxed_callback })
-        } else {
-            Err(status)
-        }
+            Client { object: Object(client_ref), callback: boxed_callback }
+        })
     }
 
     /// Creates a new CoreMIDI client.

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,18 +25,20 @@ use std::{
     ptr, 
 };
 
-use Object;
-use Client;
-use Port;
-use OutputPort;
-use InputPort;
-use Endpoint;
-use VirtualSource;
-use VirtualDestination;
-use PacketList;
-use BoxedCallback;
-use notifications::Notification;
-use result_from_status;
+use {
+    BoxedCallback,
+    Client,
+    Endpoint,
+    InputPort,
+    notifications::Notification,
+    Object,
+    OutputPort,
+    PacketList,
+    Port,
+    result_from_status,
+    VirtualSource,
+    VirtualDestination,
+};
 
 impl Client {
     /// Creates a new CoreMIDI client with support for notifications.

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,7 @@ use VirtualDestination;
 use PacketList;
 use BoxedCallback;
 use notifications::Notification;
+use result_from_status;
 
 impl Client {
     /// Creates a new CoreMIDI client with support for notifications.
@@ -63,12 +64,10 @@ impl Client {
                 client_ref.as_mut_ptr()
             )
         };
-        if status == 0 {
+        result_from_status(status, || {
             let client_ref = unsafe { client_ref.assume_init() };
-            Ok(Client { object: Object(client_ref), callback: BoxedCallback::null() })
-        } else {
-            Err(status)
-        }
+            Client { object: Object(client_ref), callback: BoxedCallback::null() }
+        })
     }
 
     /// Creates an output port through which the client may send outgoing MIDI messages to any MIDI destination.

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,10 @@ use coremidi_sys::{
 };
 
 use std::ops::Deref;
-use std::mem;
+use std::mem::{
+    self,
+    MaybeUninit,
+};
 use std::ptr;
 
 use Object;
@@ -51,13 +54,17 @@ impl Client {
     ///
     pub fn new(name: &str) -> Result<Client, OSStatus> {
         let client_name = CFString::new(name);
-        let mut client_ref: MIDIClientRef = unsafe { mem::uninitialized() };
-        let status = unsafe { MIDIClientCreate(
-            client_name.as_concrete_TypeRef(),
-            None, ptr::null_mut(),
-            &mut client_ref)
+        let mut client_ref = MaybeUninit::uninit();
+        let status = unsafe {
+            MIDIClientCreate(
+                client_name.as_concrete_TypeRef(),
+                None,
+                ptr::null_mut(),
+                client_ref.as_mut_ptr()
+            )
         };
         if status == 0 {
+            let client_ref = unsafe { client_ref.assume_init() };
             Ok(Client { object: Object(client_ref), callback: BoxedCallback::null() })
         } else {
             Err(status)

--- a/src/client.rs
+++ b/src/client.rs
@@ -179,9 +179,7 @@ impl Client {
     extern "C" fn notify_proc(notification_ptr: *const MIDINotification, ref_con: *mut c_void) {
         let _ = catch_unwind(|| unsafe {
             match Notification::from(&*notification_ptr) {
-                Ok(notification) => {
-                    BoxedCallback::call_from_raw_ptr(ref_con, &notification);
-                },
+                Ok(notification) => BoxedCallback::call_from_raw_ptr(ref_con, &notification),
                 Err(_) => {} // Skip unknown notifications
             }
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -176,10 +176,7 @@ impl Client {
         })
     }
 
-    extern "C" fn notify_proc(
-            notification_ptr: *const MIDINotification,
-            ref_con: *mut c_void) {
-
+    extern "C" fn notify_proc(notification_ptr: *const MIDINotification, ref_con: *mut c_void) {
         let _ = catch_unwind(|| unsafe {
             match Notification::from(&*notification_ptr) {
                 Ok(notification) => {
@@ -190,11 +187,7 @@ impl Client {
         });
     }
 
-    extern "C" fn read_proc(
-            pktlist: *const MIDIPacketList,
-            read_proc_ref_con: *mut c_void,
-            _: *mut c_void) { //srcConnRefCon
-
+    extern "C" fn read_proc(pktlist: *const MIDIPacketList, read_proc_ref_con: *mut c_void, _src_conn_ref_con: *mut c_void) {
         let _ = catch_unwind(|| unsafe {
             let packet_list = &*(pktlist as *const PacketList);
             BoxedCallback::call_from_raw_ptr(read_proc_ref_con, packet_list);

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,6 +1,16 @@
-use core_foundation::string::{CFString, CFStringRef};
-use core_foundation::base::{TCFType, OSStatus};
-use core_foundation::base::{CFGetRetainCount, CFTypeRef, CFIndex};
+use core_foundation::{
+    string::{
+        CFString, 
+        CFStringRef,
+    },
+    base::{
+        CFGetRetainCount,
+        CFTypeRef,
+        CFIndex, 
+        OSStatus,
+        TCFType,
+    }
+};
 
 use coremidi_sys::*;
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -81,11 +81,10 @@ impl<T> PropertyGetter<T> for StringProperty where T: From<String> {
             MIDIObjectGetStringProperty(object.0, property_key, string_ref.as_mut_ptr())
         };
         result_from_status(status, || {
-            let string: CFString = unsafe {
-                let string_ref = string_ref.assume_init();
-                TCFType::wrap_under_create_rule(string_ref)
-            };
-            string.to_string().into()
+            let string_ref = unsafe { string_ref.assume_init() };
+            if string_ref.is_null() { return "".to_string().into() };
+            let cf_string: CFString = unsafe { TCFType::wrap_under_create_rule(string_ref) };
+            cf_string.to_string().into()
         })
     }
 }


### PR DESCRIPTION
**Note that this pull request depends on https://github.com/chris-zen/coremidi/pull/22 and https://github.com/chris-zen/coremidi/pull/25**

Fixes https://github.com/chris-zen/coremidi/issues/24, using the approach suggested there. This is not a breaking change in and of itself, but https://github.com/chris-zen/coremidi/pull/25, which it depends on, is.

Along the way:
- Cleaned up imports in `client.rs` and `properties.rs`
- Refactored to reduce duplication when returning errors from status codes in `clients.rs`
