### PR TITLE
Re-export all structs necessary to process client notifications publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,13 @@ pub use endpoints::destinations::Destinations;
 pub use endpoints::sources::Sources;
 pub use packets::{PacketListIterator, Packet, PacketBuffer};
 pub use properties::{Properties, PropertyGetter, PropertySetter};
-pub use notifications::Notification;
+pub use notifications::{
+    AddedRemovedInfo,
+    IOErrorInfo,
+    Notification,
+    PropertyChangedInfo,
+};
+pub use object::ObjectType;
 
 /// Unschedules previously-sent packets for all the endpoints.
 /// See [MIDIFlushOutput](https://developer.apple.com/reference/coremidi/1495312-midiflushoutput).

--- a/src/object.rs
+++ b/src/object.rs
@@ -23,8 +23,7 @@ use properties::{
     StringProperty, IntegerProperty, BooleanProperty
 };
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ObjectType {
     Other,
     Device,


### PR DESCRIPTION
It's impossible to process MIDI Client notifications without having these structs publicly exported, so this PR does that!