### PR TITLE
Add lifetimes to objects that contain callbacks

### DIFF
--- a/src/endpoints/destinations.rs
+++ b/src/endpoints/destinations.rs
@@ -86,11 +86,11 @@ impl Iterator for DestinationsIterator {
     }
 }
 
-impl VirtualDestination {
+impl<'a> VirtualDestination<'a> {
 
 }
 
-impl Deref for VirtualDestination {
+impl<'a> Deref for VirtualDestination<'a> {
     type Target = Endpoint;
 
     fn deref(&self) -> &Endpoint {
@@ -98,7 +98,7 @@ impl Deref for VirtualDestination {
     }
 }
 
-impl Drop for VirtualDestination {
+impl<'a> Drop for VirtualDestination<'a> {
     fn drop(&mut self) {
         unsafe { MIDIEndpointDispose(self.endpoint.object.0) };
     }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -51,7 +51,7 @@ impl Deref for OutputPort {
     }
 }
 
-impl InputPort {
+impl<'a> InputPort<'a> {
 
     pub fn connect_source(&self, source: &Source) -> Result<(), OSStatus> {
         let status = unsafe { MIDIPortConnectSource(
@@ -71,7 +71,7 @@ impl InputPort {
     }
 }
 
-impl Deref for InputPort {
+impl<'a> Deref for InputPort<'a> {
     type Target = Port;
 
     fn deref(&self) -> &Port {


### PR DESCRIPTION
This is probably a breaking change, so it needs a version bump.

Consider the following code:

```rust
use coremidi;

fn count_events(counter: &mut usize) {
    let source = coremidi::Source::from_index(0).unwrap();
    let client = coremidi::Client::new("Demo").unwrap();
    let callback = |packet_list: &coremidi::PacketList| {
        let n = packet_list.iter().count();
        println!("Event count: {}", n);
        *counter += n;
    };
    let input_port = client.input_port("Input", callback).unwrap();
    input_port.connect_source(&source).unwrap();
    let mut input_line = String::new();
    println!("Press Enter to Finish");
    std::io::stdin()
        .read_line(&mut input_line)
        .ok()
        .expect("Failed to read line");
}

fn main() {
    let mut counter = 0;
    count_events(&mut counter);
    println!("Total event count: {}", counter);
}
```

With the existing code, `callback` must be `FnMut + 'static`, but this is not really necessary. We just need `callback` to outlive the `InputPort`.

With the new code, `callback` can be `FnMut + 'a` and give you an `InputPort<'a>`. The same change is made to other types that contain callbacks.