### PR TITLE
Object references can be cloned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Christian Perez-Llamas"]
 description = "CoreMIDI library for Rust"
 license = "MIT"
@@ -14,6 +14,6 @@ edition = "2021"
 
 [dependencies]
 block = "0.1.6"
-core-foundation-sys = "0.8.3"
+core-foundation-sys = "0.8.4"
 core-foundation = "0.9.3"
 coremidi-sys = "3.1.0"

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,7 +7,7 @@ use crate::object::Object;
 ///
 /// A MIDI device or external device, containing entities.
 ///
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Device {
     pub(crate) object: Object,
 }

--- a/src/endpoints/endpoint.rs
+++ b/src/endpoints/endpoint.rs
@@ -8,9 +8,9 @@ use crate::object::Object;
 /// A MIDI source or source, owned by an entity.
 /// See [MIDIEndpointRef](https://developer.apple.com/documentation/coremidi/midiendpointref).
 ///
-/// You don't need to create an endpoint directly, instead you can create system sources and sources or virtual ones from a client.
+/// You don't need to create an endpoint directly, instead you can create system sources or virtual ones from a client.
 ///
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Endpoint {
     pub(crate) object: Object,
 }

--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -19,7 +19,7 @@ use crate::Object;
 /// println!("The source at index 0 has display name '{}'", source.display_name().unwrap());
 /// ```
 ///
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Source {
     pub(crate) endpoint: Endpoint,
 }
@@ -40,6 +40,13 @@ impl Source {
             0 => None,
             _ => Some(Self::new(endpoint_ref)),
         }
+    }
+
+    /// Create a source endpoint from its name.
+    pub fn from_name(name: &str) -> Option<Source> {
+        Sources
+            .into_iter()
+            .find(|source| source.name().as_deref() == Some(name))
     }
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -7,7 +7,7 @@ use crate::object::Object;
 ///
 /// An entity that a device owns and that contains endpoints.
 ///
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Entity {
     pub(crate) object: Object,
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -45,7 +45,7 @@ impl TryFrom<i32> for ObjectType {
 ///
 /// The base class of many CoreMIDI objects.
 ///
-#[derive(Hash, Eq, PartialEq)]
+#[derive(Clone, Hash, Eq, PartialEq)]
 pub struct Object(pub(crate) MIDIObjectRef);
 
 impl Object {


### PR DESCRIPTION
After all we store references to CoreMIDI objects.