### PR TITLE
update CI cache plug-in configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
             toolchain: 1.58.1
             override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
             toolchain: ${{ matrix.rust }}
             override: true
             components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Fix a vulnerability, which arises from the usage of the cache plugin, Swatinem/rust-cache@v1, in CI configuration files. 

The plugin caches the directory ~/.cargo containing cargo's login credentials. We have already notified the author of the cache plugin, and the vulnerability has been addressed in the latest version. 
