### PR TITLE
Fix object conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Christian Perez-Llamas"]
 description = "CoreMIDI library for Rust"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The library is published into [crates.io](https://crates.io/crates/coremidi), so
 
 ```toml
 [dependencies]
-coremidi = "^0.7.1"
+coremidi = "^0.8.0"
 ```
 
 If you prefer to live in the edge ;-) you can use the master branch by including this instead:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The library is published into [crates.io](https://crates.io/crates/coremidi), so
 
 ```toml
 [dependencies]
-coremidi = "^0.7.0"
+coremidi = "^0.7.1"
 ```
 
 If you prefer to live in the edge ;-) you can use the master branch by including this instead:
@@ -68,8 +68,7 @@ git clone https://github.com/chris-zen/coremidi.git
 cd coremidi
 cargo build
 cargo test
-cargo doc
-open target/doc/coremidi/index.html
+cargo doc --open
 ```
 
 # Examples

--- a/src/any_object.rs
+++ b/src/any_object.rs
@@ -1,0 +1,139 @@
+use coremidi_sys::{MIDIObjectRef, MIDIObjectType};
+
+use crate::{Destination, Device, Entity, Object, Source};
+
+#[derive(Debug, PartialEq)]
+pub enum AnyObject {
+    Other(Object),
+    Device(Device),
+    Entity(Entity),
+    Source(Source),
+    Destination(Destination),
+    ExternalDevice(Device),
+    ExternalEntity(Entity),
+    ExternalSource(Source),
+    ExternalDestination(Destination),
+}
+
+impl AnyObject {
+    pub(crate) fn create(object_type: MIDIObjectType, object_ref: MIDIObjectRef) -> Option<Self> {
+        match object_type {
+            coremidi_sys::kMIDIObjectType_Other => Some(Self::Other(Object(object_ref))),
+            coremidi_sys::kMIDIObjectType_Device => Some(Self::Device(Device::new(object_ref))),
+            coremidi_sys::kMIDIObjectType_Entity => Some(Self::Entity(Entity::new(object_ref))),
+            coremidi_sys::kMIDIObjectType_Source => Some(Self::Source(Source::new(object_ref))),
+            coremidi_sys::kMIDIObjectType_Destination => {
+                Some(Self::Destination(Destination::new(object_ref)))
+            }
+            coremidi_sys::kMIDIObjectType_ExternalDevice => {
+                Some(Self::ExternalDevice(Device::new(object_ref)))
+            }
+            coremidi_sys::kMIDIObjectType_ExternalEntity => {
+                Some(Self::ExternalEntity(Entity::new(object_ref)))
+            }
+            coremidi_sys::kMIDIObjectType_ExternalSource => {
+                Some(Self::ExternalSource(Source::new(object_ref)))
+            }
+            coremidi_sys::kMIDIObjectType_ExternalDestination => {
+                Some(Self::ExternalDestination(Destination::new(object_ref)))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl AsRef<Object> for AnyObject {
+    fn as_ref(&self) -> &Object {
+        match self {
+            Self::Other(object) => object,
+            Self::Device(device) => &device.object,
+            Self::Entity(entity) => &entity.object,
+            Self::Source(source) => &source.object,
+            Self::Destination(destination) => &destination.object,
+            Self::ExternalDevice(device) => &device.object,
+            Self::ExternalEntity(entity) => &entity.object,
+            Self::ExternalSource(source) => &source.object,
+            Self::ExternalDestination(destination) => &destination.object,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::any_object::AnyObject;
+    use crate::{Destination, Device, Entity, Object, Source};
+
+    #[test]
+    fn any_object_create() {
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_Other, 1),
+            Some(AnyObject::Other(Object(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_Device, 1),
+            Some(AnyObject::Device(Device::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_Entity, 1),
+            Some(AnyObject::Entity(Entity::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_Source, 1),
+            Some(AnyObject::Source(Source::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_Destination, 1),
+            Some(AnyObject::Destination(Destination::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_ExternalDevice, 1),
+            Some(AnyObject::ExternalDevice(Device::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_ExternalEntity, 1),
+            Some(AnyObject::ExternalEntity(Entity::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_ExternalSource, 1),
+            Some(AnyObject::ExternalSource(Source::new(1)))
+        );
+        assert_eq!(
+            AnyObject::create(coremidi_sys::kMIDIObjectType_ExternalDestination, 1),
+            Some(AnyObject::ExternalDestination(Destination::new(1)))
+        );
+    }
+
+    #[test]
+    fn any_object_as_ref() {
+        let expected_object = Object(1);
+        assert_eq!(AnyObject::Other(Object(1)).as_ref(), &expected_object);
+        assert_eq!(AnyObject::Device(Device::new(1)).as_ref(), &expected_object);
+        assert_eq!(AnyObject::Entity(Entity::new(1)).as_ref(), &expected_object);
+        assert_eq!(AnyObject::Source(Source::new(1)).as_ref(), &expected_object);
+        assert_eq!(
+            AnyObject::Destination(Destination::new(1)).as_ref(),
+            &expected_object
+        );
+        assert_eq!(
+            AnyObject::ExternalDevice(Device::new(1)).as_ref(),
+            &expected_object
+        );
+        assert_eq!(
+            AnyObject::ExternalEntity(Entity::new(1)).as_ref(),
+            &expected_object
+        );
+        assert_eq!(
+            AnyObject::ExternalSource(Source::new(1)).as_ref(),
+            &expected_object
+        );
+        assert_eq!(
+            AnyObject::ExternalDestination(Destination::new(1)).as_ref(),
+            &expected_object
+        );
+    }
+
+    #[test]
+    fn any_object_from_error() {
+        assert_eq!(AnyObject::create(0xffff_i32, 1), None);
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,7 +7,7 @@ use crate::object::Object;
 ///
 /// A MIDI device or external device, containing entities.
 ///
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Device {
     pub(crate) object: Object,
 }
@@ -20,22 +20,22 @@ impl Device {
     }
 }
 
+impl Clone for Device {
+    fn clone(&self) -> Self {
+        Self::new(self.object.0)
+    }
+}
+
+impl AsRef<Object> for Device {
+    fn as_ref(&self) -> &Object {
+        &self.object
+    }
+}
+
 impl Deref for Device {
     type Target = Object;
 
     fn deref(&self) -> &Object {
         &self.object
-    }
-}
-
-impl From<Object> for Device {
-    fn from(object: Object) -> Self {
-        Self::new(object.0)
-    }
-}
-
-impl From<Device> for Object {
-    fn from(device: Device) -> Self {
-        device.object
     }
 }

--- a/src/endpoints/destinations.rs
+++ b/src/endpoints/destinations.rs
@@ -17,7 +17,7 @@ use crate::Object;
 /// println!("The source at index 0 has display name '{}'", source.display_name().unwrap());
 /// ```
 ///
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq)]
 pub struct Destination {
     pub(crate) endpoint: Endpoint,
 }
@@ -41,23 +41,29 @@ impl Destination {
     }
 }
 
+impl Clone for Destination {
+    fn clone(&self) -> Self {
+        Self::new(self.endpoint.object.0)
+    }
+}
+
+impl AsRef<Object> for Destination {
+    fn as_ref(&self) -> &Object {
+        &self.endpoint.object
+    }
+}
+
+impl AsRef<Endpoint> for Destination {
+    fn as_ref(&self) -> &Endpoint {
+        &self.endpoint
+    }
+}
+
 impl Deref for Destination {
     type Target = Endpoint;
 
     fn deref(&self) -> &Endpoint {
         &self.endpoint
-    }
-}
-
-impl From<Object> for Destination {
-    fn from(object: Object) -> Self {
-        Self::new(object.0)
-    }
-}
-
-impl From<Destination> for Object {
-    fn from(destination: Destination) -> Self {
-        destination.endpoint.object
     }
 }
 

--- a/src/endpoints/endpoint.rs
+++ b/src/endpoints/endpoint.rs
@@ -10,7 +10,7 @@ use crate::object::Object;
 ///
 /// You don't need to create an endpoint directly, instead you can create system sources or virtual ones from a client.
 ///
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq)]
 pub struct Endpoint {
     pub(crate) object: Object,
 }

--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -19,7 +19,7 @@ use crate::Object;
 /// println!("The source at index 0 has display name '{}'", source.display_name().unwrap());
 /// ```
 ///
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq)]
 pub struct Source {
     pub(crate) endpoint: Endpoint,
 }
@@ -50,23 +50,29 @@ impl Source {
     }
 }
 
+impl Clone for Source {
+    fn clone(&self) -> Self {
+        Self::new(self.endpoint.object.0)
+    }
+}
+
+impl AsRef<Object> for Source {
+    fn as_ref(&self) -> &Object {
+        &self.endpoint.object
+    }
+}
+
+impl AsRef<Endpoint> for Source {
+    fn as_ref(&self) -> &Endpoint {
+        &self.endpoint
+    }
+}
+
 impl Deref for Source {
     type Target = Endpoint;
 
     fn deref(&self) -> &Endpoint {
         &self.endpoint
-    }
-}
-
-impl From<Object> for Source {
-    fn from(object: Object) -> Self {
-        Self::new(object.0)
-    }
-}
-
-impl From<Source> for Object {
-    fn from(source: Source) -> Self {
-        source.endpoint.object
     }
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -7,7 +7,7 @@ use crate::object::Object;
 ///
 /// An entity that a device owns and that contains endpoints.
 ///
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Entity {
     pub(crate) object: Object,
 }
@@ -20,22 +20,22 @@ impl Entity {
     }
 }
 
+impl Clone for Entity {
+    fn clone(&self) -> Self {
+        Self::new(self.object.0)
+    }
+}
+
+impl AsRef<Object> for Entity {
+    fn as_ref(&self) -> &Object {
+        &self.object
+    }
+}
+
 impl Deref for Entity {
     type Target = Object;
 
     fn deref(&self) -> &Object {
         &self.object
-    }
-}
-
-impl From<Object> for Entity {
-    fn from(object: Object) -> Self {
-        Self::new(object.0)
-    }
-}
-
-impl From<Entity> for Object {
-    fn from(entity: Entity) -> Self {
-        entity.object
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ For handling low level MIDI data you may look into:
 
 */
 
+mod any_object;
 mod client;
 mod device;
 mod endpoints;
@@ -63,7 +64,7 @@ pub use crate::endpoints::sources::{Source, Sources, VirtualSource};
 pub use crate::entity::Entity;
 pub use crate::events::{EventBuffer, EventList, EventListIter, EventPacket, Timestamp};
 pub use crate::notifications::{AddedRemovedInfo, IoErrorInfo, Notification, PropertyChangedInfo};
-pub use crate::object::{Object, ObjectType};
+pub use crate::object::Object;
 pub use crate::packets::{Packet, PacketBuffer, PacketList, PacketListIterator};
 pub use crate::ports::{InputPort, InputPortWithContext, OutputPort};
 pub use crate::properties::{

--- a/src/object.rs
+++ b/src/object.rs
@@ -7,45 +7,11 @@ use crate::properties::{
     BooleanProperty, IntegerProperty, Properties, PropertyGetter, PropertySetter, StringProperty,
 };
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum ObjectType {
-    Other,
-    Device,
-    Entity,
-    Source,
-    Destination,
-    ExternalDevice,
-    ExternalEntity,
-    ExternalSource,
-    ExternalDestination,
-}
-
-impl TryFrom<i32> for ObjectType {
-    type Error = i32;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            coremidi_sys::kMIDIObjectType_Other => Ok(ObjectType::Other),
-            coremidi_sys::kMIDIObjectType_Device => Ok(ObjectType::Device),
-            coremidi_sys::kMIDIObjectType_Entity => Ok(ObjectType::Entity),
-            coremidi_sys::kMIDIObjectType_Source => Ok(ObjectType::Source),
-            coremidi_sys::kMIDIObjectType_Destination => Ok(ObjectType::Destination),
-            coremidi_sys::kMIDIObjectType_ExternalDevice => Ok(ObjectType::ExternalDevice),
-            coremidi_sys::kMIDIObjectType_ExternalEntity => Ok(ObjectType::ExternalEntity),
-            coremidi_sys::kMIDIObjectType_ExternalSource => Ok(ObjectType::ExternalSource),
-            coremidi_sys::kMIDIObjectType_ExternalDestination => {
-                Ok(ObjectType::ExternalDestination)
-            }
-            unknown => Err(unknown),
-        }
-    }
-}
-
 /// A [MIDI Object](https://developer.apple.com/documentation/coremidi/midiobjectref).
 ///
 /// The base class of many CoreMIDI objects.
 ///
-#[derive(Clone, Hash, Eq, PartialEq)]
+#[derive(Hash, Eq, PartialEq)]
 pub struct Object(pub(crate) MIDIObjectRef);
 
 impl Object {
@@ -126,55 +92,5 @@ impl Object {
 impl fmt::Debug for Object {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Object({:x})", self.0 as usize)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::object::ObjectType;
-
-    #[test]
-    fn objecttype_try_from() {
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_Other),
-            Ok(ObjectType::Other)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_Device),
-            Ok(ObjectType::Device)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_Entity),
-            Ok(ObjectType::Entity)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_Source),
-            Ok(ObjectType::Source)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_Destination),
-            Ok(ObjectType::Destination)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_ExternalDevice),
-            Ok(ObjectType::ExternalDevice)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_ExternalEntity),
-            Ok(ObjectType::ExternalEntity)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_ExternalSource),
-            Ok(ObjectType::ExternalSource)
-        );
-        assert_eq!(
-            ObjectType::try_from(coremidi_sys::kMIDIObjectType_ExternalDestination),
-            Ok(ObjectType::ExternalDestination)
-        );
-    }
-
-    #[test]
-    fn objecttype_from_error() {
-        assert_eq!(ObjectType::try_from(0xffff_i32), Err(0xffff));
     }
 }


### PR DESCRIPTION
- Removes the capability to convert between different types of objects.
- Allows to clone `Device`, `Entity`, `Source` and `Destination` because they are just object references which lifetime is managed by CoreMIDI.
- Introduces the type `AnyObject` that can encapsulate different types of objects as needed by the Notifications

**BREAKING CHANGES:**
- The Notifications structs change from using `ObjectType/Object` to using `AnyObject`.
- Several `From` conversions are removed.