### PR TITLE
Add a function to create a Source from a unique id. 

### DIFF
--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -51,20 +51,10 @@ impl Source {
     }
 
     /// Create a source from it's unique id.
+    /// See [MIDIObjectFindByUniqueID](https://developer.apple.com/documentation/coremidi/1495191-midiobjectfindbyuniqueid).
+    ///
     pub fn from_unique_id(unique_id: u32) -> Option<Source> {
-        let mut obj_ref: MIDIObjectRef = 0;
-        let mut obj_type: MIDIObjectType = 0;
-        let status = unsafe {
-            MIDIObjectFindByUniqueID(unique_id as MIDIUniqueID, &mut obj_ref, &mut obj_type)
-        };
-        if status != 0 {
-            return None;
-        }
-        if obj_type == kMIDIObjectType_Source {
-            Some(Source::new(obj_ref as MIDIEndpointRef))
-        } else {
-            None
-        }
+        Sources::find_by_unique_id(unique_id)
     }
 }
 
@@ -118,6 +108,22 @@ impl Sources {
     ///
     pub fn count() -> usize {
         unsafe { MIDIGetNumberOfSources() as usize }
+    }
+
+    /// Find a source based on its unique id.
+    /// See [MIDIObjectFindByUniqueID](https://developer.apple.com/documentation/coremidi/1495191-midiobjectfindbyuniqueid).
+    ///
+    fn find_by_unique_id(unique_id: u32) -> Option<Source> {
+        let mut obj_ref: MIDIObjectRef = 0;
+        let mut obj_type: MIDIObjectType = 0;
+        let status = unsafe {
+            MIDIObjectFindByUniqueID(unique_id as MIDIUniqueID, &mut obj_ref, &mut obj_type)
+        };
+        if status != 0 || obj_type != kMIDIObjectType_Source {
+            None
+        } else {
+            Some(Source::new(obj_ref as MIDIEndpointRef))
+        }
     }
 }
 

--- a/src/endpoints/sources.rs
+++ b/src/endpoints/sources.rs
@@ -2,8 +2,9 @@ use core_foundation_sys::base::OSStatus;
 use std::ops::Deref;
 
 use coremidi_sys::{
-    ItemCount, MIDIEndpointDispose, MIDIEndpointRef, MIDIGetNumberOfSources, MIDIGetSource,
-    MIDIReceived, MIDIReceivedEventList,
+    kMIDIObjectType_Source, ItemCount, MIDIEndpointDispose, MIDIEndpointRef,
+    MIDIGetNumberOfSources, MIDIGetSource, MIDIObjectFindByUniqueID, MIDIObjectRef, MIDIObjectType,
+    MIDIReceived, MIDIReceivedEventList, MIDIUniqueID,
 };
 
 use crate::endpoints::endpoint::Endpoint;
@@ -47,6 +48,23 @@ impl Source {
         Sources
             .into_iter()
             .find(|source| source.name().as_deref() == Some(name))
+    }
+
+    /// Create a source from it's unique id.
+    pub fn from_unique_id(unique_id: u32) -> Option<Source> {
+        let mut obj_ref: MIDIObjectRef = 0;
+        let mut obj_type: MIDIObjectType = 0;
+        let status = unsafe {
+            MIDIObjectFindByUniqueID(unique_id as MIDIUniqueID, &mut obj_ref, &mut obj_type)
+        };
+        if status != 0 {
+            return None;
+        }
+        if obj_type == kMIDIObjectType_Source {
+            Some(Source::new(obj_ref as MIDIEndpointRef))
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
I wanted to be able to create a source from a unique id. The advantage of this over using name or index is that the unique id is unique to the device, even if more than one of the same device is plugged in, and it persists across reboots and device disconnects.

Also, this allows you to create a source for a device even if it's not currently plugged in. In my testing MacOS will automatically start sending midi messages to your listener once the device is plugged in.