### PR TITLE
Feature | Expose OS status code type alias publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod ports;
 mod properties;
 mod protocol;
 
-use core_foundation_sys::base::OSStatus;
+pub use core_foundation_sys::base::OSStatus;
 
 use coremidi_sys::{MIDIFlushOutput, MIDIRestart};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ fn result_from_status<T, F: FnOnce() -> T>(status: OSStatus, f: F) -> Result<T, 
     }
 }
 
-/// Convert an OSSStatus into a Result<(), OSStatus>
+/// Convert an OSStatus into a Result<(), OSStatus>
 fn unit_result_from_status(status: OSStatus) -> Result<(), OSStatus> {
     result_from_status(status, || ())
 }


### PR DESCRIPTION
## Changes

### Expose OS status code type alias publicly

It feels like the `OSStatus` type alias should be publicly exposed since the type itself is in the public API - used as the `Err` variant in most `Result` return values.

### Fix a small docs typo