### PR TITLE
Check for null pointer after MIDIPacketListAdd/MIDIEventListAdd

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -220,6 +220,10 @@ impl EventBuffer {
             )
         };
 
+        if current_packet_ptr.is_null() {
+            panic!("MIDIEventListAdd was unable to add the event")
+        }
+
         self.current_packet_offset = unsafe {
             (current_packet_ptr as *const u8).offset_from(packet_list_ptr as *const u8) as usize
         };

--- a/src/events.rs
+++ b/src/events.rs
@@ -221,7 +221,7 @@ impl EventBuffer {
         };
 
         if current_packet_ptr.is_null() {
-            panic!("MIDIEventListAdd was unable to add the event")
+            panic!("not enough room in the packet for the event")
         }
 
         self.current_packet_offset = unsafe {

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -205,6 +205,11 @@ impl PacketBuffer {
                 data.as_ptr(),
             )
         };
+
+        if current_packet_ptr.is_null() {
+            panic!("MIDIPacketListAdd was unable to add the packet")
+        }
+
         let current_packet_offset = unsafe {
             (current_packet_ptr as *const u8).offset_from(packet_list_ptr as *const u8) as usize
         };
@@ -280,6 +285,10 @@ impl PacketBuffer {
                 data.as_ptr(),
             )
         };
+
+        if current_packet_ptr.is_null() {
+            panic!("MIDIPacketListAdd was unable to add the packet")
+        }
 
         self.current_packet_offset = unsafe {
             (current_packet_ptr as *const u8).offset_from(packet_list_ptr as *const u8) as usize

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -207,7 +207,7 @@ impl PacketBuffer {
         };
 
         if current_packet_ptr.is_null() {
-            panic!("MIDIPacketListAdd was unable to add the packet")
+            panic!("not enough room in the packet for the event")
         }
 
         let current_packet_offset = unsafe {

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -287,7 +287,7 @@ impl PacketBuffer {
         };
 
         if current_packet_ptr.is_null() {
-            panic!("MIDIPacketListAdd was unable to add the packet")
+            panic!("not enough room in the packet for the event")
         }
 
         self.current_packet_offset = unsafe {


### PR DESCRIPTION
MIDIPacketListAdd/MIDIEventListAdd can return null pointers. This leads to unsoundness (see #57).

Ideally the error would be handled by the caller, but that requires a changed signature. So a panic is the best we can do for now.