### PR TITLE
fix mismatched_lifetime_syntaxes lint

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -36,7 +36,7 @@ impl EventList {
 
     /// Get an iterator for the packets in the list.
     ///
-    pub fn iter(&self) -> EventListIter {
+    pub fn iter(&self) -> EventListIter<'_> {
         EventListIter {
             count: self.len(),
             packet_ptr: std::ptr::addr_of!(self.0.packet) as *const MIDIEventPacket,

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -38,7 +38,7 @@ impl PacketList {
 
     /// Get an iterator for the packets in the list.
     ///
-    pub fn iter(&self) -> PacketListIterator {
+    pub fn iter(&self) -> PacketListIterator<'_> {
         PacketListIterator {
             count: self.len(),
             packet_ptr: std::ptr::addr_of!(self.0.packet) as *const MIDIPacket,


### PR DESCRIPTION
```log
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/events.rs:39:17
   |
39 |     pub fn iter(&self) -> EventListIter {
   |                 ^^^^^     ^^^^^^^^^^^^^ the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
39 |     pub fn iter(&self) -> EventListIter<'_> {
   |                                        ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/packets.rs:41:17
   |
41 |     pub fn iter(&self) -> PacketListIterator {
   |                 ^^^^^     ^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
41 |     pub fn iter(&self) -> PacketListIterator<'_> {
   |                                             ++++
```