### PR TITLE
Replace block with objc/block2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.75"
 
 [dependencies]
-block = "0.1.6"
+block2 = "0.6"
 core-foundation-sys = "0.8.7"
 core-foundation = "0.10.1"
 coremidi-sys = "3.1.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use block::RcBlock;
+use block2::RcBlock;
 use core_foundation::{
     base::{OSStatus, TCFType},
     string::CFString,
@@ -8,9 +8,9 @@ use std::{mem::MaybeUninit, ops::Deref, os::raw::c_void, ptr};
 
 use coremidi_sys::{
     MIDIClientCreate, MIDIClientCreateWithBlock, MIDIDestinationCreateWithBlock,
-    MIDIDestinationCreateWithProtocol, MIDIEventList, MIDIInputPortCreateWithBlock,
+    MIDIDestinationCreateWithProtocol, MIDIInputPortCreateWithBlock,
     MIDIInputPortCreateWithProtocol, MIDINotification, MIDINotifyBlock, MIDIOutputPortCreate,
-    MIDIPacketList, MIDIReadBlock, MIDIReceiveBlock, MIDISourceCreate,
+    MIDIReadBlock, MIDIReceiveBlock, MIDISourceCreate,
 };
 
 use crate::ports::InputPortWithContext;
@@ -282,46 +282,43 @@ impl Client {
         })
     }
 
-    fn notify_block(callback: NotifyCallback) -> RcBlock<(*const MIDINotification,), ()> {
-        let notify_block = block::ConcreteBlock::new(move |message: *const MIDINotification| {
-            let message = unsafe { &*message };
+    fn notify_block(callback: NotifyCallback) -> RcBlock<dyn Fn(*const c_void) -> ()> {
+        RcBlock::new(move |message: *const c_void| {
+            let message = unsafe { &*(message as *const MIDINotification) };
             if let Ok(notification) = Notification::try_from(message) {
                 match &callback {
                     NotifyCallback::ByReference(f) => (f.borrow_mut())(&notification),
                     NotifyCallback::ByOwnership(f) => (f.borrow_mut())(notification),
                 }
             }
-        });
-        notify_block.copy()
+        })
     }
 
-    fn read_block<F>(callback: F) -> RcBlock<(*const MIDIPacketList, *mut c_void), ()>
+    fn read_block<F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void) -> ()>
     where
         F: FnMut(&PacketList) + Send + 'static,
     {
         let callback = RefCell::new(callback);
-        let read_block = block::ConcreteBlock::new(
-            move |pktlist: *const MIDIPacketList, _src_conn_ref_con: *mut c_void| {
+        RcBlock::new(
+            move |pktlist: *const c_void, _src_conn_ref_con: *mut c_void| {
                 let packet_list = unsafe { &*(pktlist as *const PacketList) };
                 (callback.borrow_mut())(packet_list);
             },
-        );
-        read_block.copy()
+        )
     }
 
-    fn receive_block<T, F>(callback: F) -> RcBlock<(*const MIDIEventList, *mut c_void), ()>
+    fn receive_block<T, F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void) -> ()>
     where
         F: FnMut(&EventList, &mut T) + Send + 'static,
     {
         let callback = RefCell::new(callback);
-        let receive_block = block::ConcreteBlock::new(
-            move |evtlist: *const MIDIEventList, src_conn_ref_con: *mut c_void| {
+        RcBlock::new(
+            move |evtlist: *const c_void, src_conn_ref_con: *mut c_void| {
                 let event_list = unsafe { &*(evtlist as *const EventList) };
                 let context = unsafe { &mut *(src_conn_ref_con as *mut T) };
                 (callback.borrow_mut())(event_list, context);
             },
-        );
-        receive_block.copy()
+        )
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,7 +282,7 @@ impl Client {
         })
     }
 
-    fn notify_block(callback: NotifyCallback) -> RcBlock<dyn Fn(*const c_void) -> ()> {
+    fn notify_block(callback: NotifyCallback) -> RcBlock<dyn Fn(*const c_void)> {
         RcBlock::new(move |message: *const c_void| {
             let message = unsafe { &*(message as *const MIDINotification) };
             if let Ok(notification) = Notification::try_from(message) {
@@ -294,7 +294,7 @@ impl Client {
         })
     }
 
-    fn read_block<F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void) -> ()>
+    fn read_block<F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void)>
     where
         F: FnMut(&PacketList) + Send + 'static,
     {
@@ -307,7 +307,7 @@ impl Client {
         )
     }
 
-    fn receive_block<T, F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void) -> ()>
+    fn receive_block<T, F>(callback: F) -> RcBlock<dyn Fn(*const c_void, *mut c_void)>
     where
         F: FnMut(&EventList, &mut T) + Send + 'static,
     {


### PR DESCRIPTION
Addresses the following deprecation warning:
```
warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

https://github.com/chris-zen/coremidi/issues/64